### PR TITLE
anon users no longer get error when clicking on profiles

### DIFF
--- a/app.py
+++ b/app.py
@@ -106,7 +106,7 @@ def index():
 @app.route('/stream/<username>')
 def stream(username = None):
 	template = 'stream.html'
-	if username and username != current_user.username:
+	if username and (current_user.is_anonymous or username != current_user.username):
 		try:
 			user = models.User.select().where(models.User.username**username).get()
 		except models.DoesNotExist:


### PR DESCRIPTION
The server crashes when the client isn't logged in and tries to view a profile. This checks if the user is anonymous before trying to access the username of a current_user that isn't logged in and crashing. 